### PR TITLE
chore: rename devops-ci to platform-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,17 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+*                                               @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 
 ############################
 #####  Project Files  ######
 ############################
 
-/src/**                                         @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-/__tests__/**                                   @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-/resources/**                                   @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-/examples/**                                    @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-/.husky/**                                      @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/src/**                                         @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/__tests__/**                                   @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/resources/**                                   @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/examples/**                                    @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/.husky/**                                      @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 
 #########################
 #####  Core Files  ######
@@ -21,30 +21,30 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/.github/                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Gradle project files
-/build-logic/**                                 @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-**/*.gradle.kts                                 @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-/gradle/**                                      @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/build-logic/**                                 @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+**/*.gradle.kts                                 @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/gradle/**                                      @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-.remarkrc                                       @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/config/                                        @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+.remarkrc                                       @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 
 # Semantic Release Configuration
-.releaserc                                      @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+.releaserc                                      @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+/README.md                                      @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 **/LICENSE                                      @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+**/codecov.yml                                  @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
-**/.gitignore.*                                 @hashgraph/developer-advocates @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+**/.gitignore                                   @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera
+**/.gitignore.*                                 @hashgraph/developer-advocates @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/iobuilders-hedera


### PR DESCRIPTION
Description:

Rename devops-ci to platform-ci and devops-ci-committers to platform-ci-committers

Related Issue(s):

Fixes #60
