### PR TITLE
fix: esm compatibility

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -34,6 +34,13 @@ export const DEFAULT_DFNS_SERVICE_ACCOUNT_PRIVATE_KEY =
   'resources/keys/dfns-priv.pem';
 export const TEST_TIMEOUT = 10000; // 10 seconds
 
+const resolvePrivateKey = (privateKeyOrPath: string): string =>
+  pathRegex.test(privateKeyOrPath)
+    ? fs.readFileSync(path.resolve(privateKeyOrPath), 'utf8')
+    : privateKeyOrPath.replace(/\\n/g, '\n').trim().startsWith('-----BEGIN')
+      ? privateKeyOrPath.replace(/\\n/g, '\n')
+      : Buffer.from(privateKeyOrPath, 'base64').toString('utf8');
+
 //* Fireblocks configuration
 const fireblocksApiSecretKey =
   process.env.FIREBLOCKS_API_SECRET_KEY || DEFAULT_FIREBLOCKS_API_SECRET_KEY;
@@ -52,9 +59,7 @@ const dfnsServiceAccountPrivateKey =
   process.env.DFNS_SERVICE_ACCOUNT_PRIVATE_KEY ||
   DEFAULT_DFNS_SERVICE_ACCOUNT_PRIVATE_KEY;
 export const dfnsConfig = new DFNSConfig(
-  pathRegex.test(dfnsServiceAccountPrivateKey)
-    ? fs.readFileSync(path.resolve(dfnsServiceAccountPrivateKey), 'utf8')
-    : Buffer.from(dfnsServiceAccountPrivateKey, 'base64').toString('utf8'),
+  resolvePrivateKey(dfnsServiceAccountPrivateKey),
   process.env.DFNS_SERVICE_ACCOUNT_CREDENTIAL_ID ?? '',
   process.env.DFNS_SERVICE_ACCOUNT_AUTHORIZATION_TOKEN ?? '',
   process.env.DFNS_APP_ORIGIN ?? '',
@@ -64,9 +69,7 @@ export const dfnsConfig = new DFNSConfig(
   process.env.DFNS_WALLET_PUBLIC_KEY ?? ''
 );
 export const dfnsConfig_ECDSA = new DFNSConfig(
-  pathRegex.test(dfnsServiceAccountPrivateKey)
-    ? fs.readFileSync(path.resolve(dfnsServiceAccountPrivateKey), 'utf8')
-    : Buffer.from(dfnsServiceAccountPrivateKey, 'base64').toString('utf8'),
+  resolvePrivateKey(dfnsServiceAccountPrivateKey),
   process.env.DFNS_SERVICE_ACCOUNT_CREDENTIAL_ID ?? '',
   process.env.DFNS_SERVICE_ACCOUNT_AUTHORIZATION_TOKEN ?? '',
   process.env.DFNS_APP_ORIGIN ?? '',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,9 @@ import licenseHeader from 'eslint-plugin-license-header';
 
 export default [
   {
+    ignores: ['lib/**', 'dist/**', 'build/**', 'node_modules/**'],
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'], // Adjust the file patterns as needed
     languageOptions: {
       globals: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-custodians-integration",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-custodians-integration",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "cpu": [
         "x86_64",
         "x64",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-custodians-integration",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-custodians-integration",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "cpu": [
         "x86_64",
         "x64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-custodians-integration",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A library to provide integration with custodial wallets",
   "homepage": "https://github.com/hashgraph/hedera-custodians-library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lib"
   ],
   "scripts": {
-    "compile": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
+    "compile": "tsc -p tsconfig.json && node scripts/fix-esm-imports.mjs && tsc -p tsconfig-cjs.json",
     "clean": "rimraf build coverage",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/scripts/fix-esm-imports.mjs
+++ b/scripts/fix-esm-imports.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Post-build script: adds .js extensions to relative imports in lib/esm/
+ *
+ * Node.js ESM requires explicit file extensions in relative import specifiers.
+ * TypeScript with "moduleResolution": "node" doesn't enforce this, so tsc
+ * emits files without extensions. This script fixes the compiled output.
+ *
+ * Handles two cases:
+ *   ./foo        → ./foo.js          (when lib/esm/.../foo.js exists)
+ *   ./foo        → ./foo/index.js    (when lib/esm/.../foo/ is a directory)
+ */
+
+import { readdir, readFile, writeFile, access } from 'fs/promises';
+import { join, extname, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ESM_DIR = join(__dirname, '..', 'lib', 'esm');
+
+const SKIP_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.json', '.node']);
+
+async function exists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the correct ESM-compatible path for a relative import.
+ * Checks the file system to distinguish file vs directory imports.
+ */
+async function resolveExtension(importPath, fromFile) {
+  if (!importPath.startsWith('./') && !importPath.startsWith('../')) {
+    return importPath; // not a relative import
+  }
+  const ext = extname(importPath);
+  if (SKIP_EXTENSIONS.has(ext)) {
+    return importPath; // already has a valid extension
+  }
+
+  const base = resolve(dirname(fromFile), importPath);
+
+  if (await exists(base + '.js')) {
+    return importPath + '.js';
+  }
+  if (await exists(join(base, 'index.js'))) {
+    return importPath + '/index.js';
+  }
+
+  // Fallback: add .js
+  return importPath + '.js';
+}
+
+async function fixImports(code, fromFile) {
+  const staticRe =
+    /((?:import|export)[^'"]*?from\s+)(["'])(\.{1,2}\/[^'"]*?)\2/g;
+  const dynamicRe = /(\bimport\s*\(\s*)(["'])(\.{1,2}\/[^'"]*?)\2(\s*\))/g;
+
+  let result = code;
+
+  const staticMatches = [...code.matchAll(staticRe)];
+  for (const match of staticMatches) {
+    const [full, keyword, quote, importPath] = match;
+    const fixed = await resolveExtension(importPath, fromFile);
+    if (fixed !== importPath) {
+      result = result.replace(full, `${keyword}${quote}${fixed}${quote}`);
+    }
+  }
+
+  const dynamicMatches = [...result.matchAll(dynamicRe)];
+  for (const match of dynamicMatches) {
+    const [full, prefix, quote, importPath, suffix] = match;
+    const fixed = await resolveExtension(importPath, fromFile);
+    if (fixed !== importPath) {
+      result = result.replace(
+        full,
+        `${prefix}${quote}${fixed}${quote}${suffix}`
+      );
+    }
+  }
+
+  return result;
+}
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(fullPath)));
+    } else if (entry.isFile() && extname(entry.name) === '.js') {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function main() {
+  const files = await walk(ESM_DIR);
+  let fixed = 0;
+  let unchanged = 0;
+
+  for (const file of files) {
+    const original = await readFile(file, 'utf8');
+    const patched = await fixImports(original, file);
+    if (patched !== original) {
+      await writeFile(file, patched, 'utf8');
+      fixed++;
+    } else {
+      unchanged++;
+    }
+  }
+
+  console.log(
+    `ESM import fix: ${fixed} files updated, ${unchanged} already correct (${ESM_DIR})`
+  );
+}
+
+main().catch((err) => {
+  console.error('fix-esm-imports failed:', err);
+  process.exit(1);
+});

--- a/src/models/EcdsaAsn1Signature.ts
+++ b/src/models/EcdsaAsn1Signature.ts
@@ -18,12 +18,19 @@
  *
  */
 
-import {
-  ASN1Element,
-  ASN1TagClass,
-  ASN1UniversalType,
-  DERElement,
-} from 'asn1-ts';
+// asn1-ts is a CJS module with __esModule:true but no `export default`.
+// - Node.js ESM strict: named imports fail; `import * as ns` gives ns.default = module.exports
+// - Webpack: `import * as ns` exposes named exports directly; ns.default = undefined
+// The `ns.default ?? ns` pattern handles both environments correctly.
+import type * as asn1tsTypes from 'asn1-ts';
+import * as asn1tsNamespace from 'asn1-ts';
+
+type ASN1Element = asn1tsTypes.ASN1Element;
+type DERElement = asn1tsTypes.DERElement;
+
+const asn1ts = (asn1tsNamespace as any).default ?? asn1tsNamespace;
+const { ASN1TagClass, ASN1UniversalType, DERElement } =
+  asn1ts as unknown as typeof asn1tsTypes;
 
 /**
  * Represents an ECDSA ASN.1 signature.


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This pull request improves compatibility with Node.js ESM by ensuring that all relative imports in the compiled ESM output have explicit `.js` extensions, and also addresses compatibility issues with the `asn1-ts` module import in ESM environments. The changes automate post-build import fixing and make the codebase more robust across different module systems.

**ESM compatibility improvements:**

* Added a new post-build script `scripts/fix-esm-imports.mjs` that scans the `lib/esm/` output directory and rewrites all relative import/export paths to include explicit `.js` extensions, as required by Node.js ESM. The script is now run automatically as part of the `compile` npm script. [[1]](diffhunk://#diff-2b846443520e8539a2ab9b61d116d1a7b409ea4b5883b88e9404f1fb568162a1R1-R127) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L46-R46)

**Module import robustness:**

* Updated `src/models/EcdsaAsn1Signature.ts` to use a safer import pattern for the `asn1-ts` library, ensuring it works correctly in both Node.js ESM and Webpack environments by handling the differences in how named and default exports are exposed.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
